### PR TITLE
Add network policy for cilium so that crd-install job can talk to api-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Content of the `/helm` directory will be bundled, released and pushed to the `ap
 
 ## Usage
 
-How to work within this repository?
+This app contains a helm chart for [`cluster-api-ipam-provider-in-cluster`](https://github.com/kubernetes-sigs/cluster-api-ipam-provider-in-cluster).
+The application itself assumes `IpAddress` and `IpAddressClaim` custom resource definitions to exist in the cluster. 
+These are installed together with common CAPI CRDs.
 
 ### apply new `kustomize` changes to the charts
 
@@ -29,6 +31,15 @@ How to work within this repository?
 2. run `make all`
 3. also make sure the tag of the container image in the default values.yaml is updated if you want to use the newly released thing
 
+### deploy the latest version of app
+```
+k gs template app --catalog control-plane-test-catalog \
+                  --name cluster-api-ipam-provider-in-cluster \
+                  --target-namespace default \
+                  --organization giantswarm \
+                  --cluster-name foo \
+                  --version <latest-released-version>-gitSHa | k apply -f -
+```
 # Useful links
 
 * [Upstream repo](https://github.com/kubernetes-sigs/cluster-api-ipam-provider-in-cluster)

--- a/config/kustomize/kustomization.yaml
+++ b/config/kustomize/kustomization.yaml
@@ -25,6 +25,12 @@ patches:
     labelSelector: cluster.x-k8s.io/provider=ipam-in-cluster
 - patch: |-
     - op: remove
+      path: /metadata/creationTimestamp
+  target:
+    kind: CustomResourceDefinition
+    labelSelector: cluster.x-k8s.io/provider=ipam-in-cluster
+- patch: |-
+    - op: remove
       path: /spec/template/spec/volumes/0
     - op: remove
       path: /spec/template/spec/containers/0/volumeMounts/0

--- a/hack/prepare-helmchart.sh
+++ b/hack/prepare-helmchart.sh
@@ -11,8 +11,8 @@ find config/kustomize/tmp/ -regex ".*apiextensions.k8s.io_v1_customresourcedefin
 	mv -v config/kustomize/tmp/${filename} helm/${1}/files/${filename/apiextensions.k8s.io_v1_customresourcedefinition_/}
 done
 
-find helm/${1}/files/ -regex ".*infrastructure.cluster.x-k8s.io.yaml" | while read f; do
-	mv -v ${f} ${f/infrastructure.cluster.x-k8s.io./}
+find helm/${1}/files/ -regex ".*ipam.cluster.x-k8s.io.yaml" | while read f; do
+	mv -v ${f} ${f/ipam.cluster.x-k8s.io./}
 done
 
 # move everything from current tmp workdir over to helm

--- a/helm/cluster-api-ipam-provider-in-cluster/files/globalinclusterippools.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/files/globalinclusterippools.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/caip-serving-cert'
     controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: "null"
   labels:
     app.giantswarm.io/branch: '{{ .Values.project.branch }}'
     app.giantswarm.io/commit: '{{ .Values.project.commit }}'

--- a/helm/cluster-api-ipam-provider-in-cluster/files/inclusterippools.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/files/inclusterippools.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/caip-serving-cert'
     controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: "null"
   labels:
     app.giantswarm.io/branch: '{{ .Values.project.branch }}'
     app.giantswarm.io/commit: '{{ .Values.project.commit }}'

--- a/helm/cluster-api-ipam-provider-in-cluster/templates/crd-install/crd-netpol.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/templates/crd-install/crd-netpol.yaml
@@ -35,4 +35,27 @@ spec:
   policyTypes:
   - Egress
   - Ingress
+{{- if .Capabilities.APIVersions.Has "cilium.io/v2/CiliumNetworkPolicy" }}
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ include "crdInstall" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    # create hook dependencies in the right order
+    "helm.sh/hook-weight": "-7"
+    {{- include "crdInstallAnnotations" . | nindent 4 }}
+  labels:
+    app.kubernetes.io/component: {{ include "crdInstall" . | quote }}
+    {{- include "labels.selector" . | nindent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/component: {{ include "crdInstall" . | quote }}
+      {{- include "labels.selector" . | nindent 6 }}
+  egress:
+    - toEntities:
+        - kube-apiserver
+{{- end }}
 {{- end }}


### PR DESCRIPTION
also remove `creationTimestamp: "null"` to fix:

```
+ kubectl apply -f /data/
unable to decode "/data/globalinclusterippools.yaml": parsing time "null" as "2006-01-02T15:04:05Z07:00": cannot parse "null" as "2006"
unable to decode "/data/inclusterippools.yaml": parsing time "null" as "2006-01-02T15:04:05Z07:00": cannot parse "null" as "2006"
```