### PR TITLE
Add explicit feature flag for cpol

### DIFF
--- a/helm/cluster-api-ipam-provider-in-cluster/templates/crd-install/crd-netpol.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/templates/crd-install/crd-netpol.yaml
@@ -36,6 +36,7 @@ spec:
   - Egress
   - Ingress
 {{- if .Capabilities.APIVersions.Has "cilium.io/v2/CiliumNetworkPolicy" }}
+{{- if .Values.ciliumNetworkPolicy.enabled }}
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -57,5 +58,6 @@ spec:
   egress:
     - toEntities:
         - kube-apiserver
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm/cluster-api-ipam-provider-in-cluster/values.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/values.yaml
@@ -19,3 +19,6 @@ resources:
   requests:
     cpu: 100m
     memory: 64Mi
+
+ciliumNetworkPolicy:
+  enabled: true


### PR DESCRIPTION
the default should be imho `true` because this app will be installed in vsphere MCs where the default behavior of cilium is "everything locked"