### PR TITLE
Create pool should wait till crds are created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Network policy (cilium and normal) for manager.
+
 ## [0.0.2] - 2023-07-04
 
 ### Added

--- a/helm/cluster-api-ipam-provider-in-cluster/templates/custom/manager-netpol.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/templates/custom/manager-netpol.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ $.Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.giantswarm.io/branch: '{{ .Values.project.branch }}'
+    app.giantswarm.io/commit: '{{ .Values.project.commit }}'
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
+    app.kubernetes.io/name: '{{ .Chart.Name }}'
+    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+    cluster.x-k8s.io/provider: ipam-in-cluster
+    helm.sh/chart: '{{ .Chart.Name }}'
+spec:
+  podSelector:
+    matchLabels:
+      cluster.x-k8s.io/provider: ipam-in-cluster
+      control-plane: controller-manager
+  # allow egress traffic to the Kubernetes API
+  egress:
+  - ports:
+    - port: 443
+      protocol: TCP
+    # legacy port kept for compatibility
+    - port: 6443
+      protocol: TCP
+    to:
+    {{- range tuple "10.0.0.0/8" "172.16.0.0/12" "192.168.0.0/16" "100.64.0.0/10" }}
+    - ipBlock:
+        cidr: {{ . }}
+    {{- end }}
+  # deny ingress traffic
+  ingress: []
+  policyTypes:
+  - Egress
+  - Ingress
+{{- if .Values.ciliumNetworkPolicy.enabled }}
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ $.Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.giantswarm.io/branch: '{{ .Values.project.branch }}'
+    app.giantswarm.io/commit: '{{ .Values.project.commit }}'
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
+    app.kubernetes.io/name: '{{ .Chart.Name }}'
+    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+    cluster.x-k8s.io/provider: ipam-in-cluster
+    helm.sh/chart: '{{ .Chart.Name }}'
+spec:
+  endpointSelector:
+    matchLabels:
+      cluster.x-k8s.io/provider: ipam-in-cluster
+      control-plane: controller-manager
+  egress:
+    - toEntities:
+        - kube-apiserver
+{{- end }}
+{{- end }}

--- a/helm/cluster-api-ipam-provider-in-cluster/templates/pools/job.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/templates/pools/job.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.enabled }}
+{{- if .Values.inClusterIpPool.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-in-cluster-ip-pool
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: create-in-cluster-ip-pool
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "-1"
+    helm.sh/hook-delete-policy: "before-hook-creation,hook-succeeded,hook-failed"
+spec:
+  backoffLimit: 50
+  template:
+    metadata:
+      labels:
+        app: create-in-cluster-ip-pool
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: install-crs
+      volumes:
+      - name: in-cluster-ip-pool
+        configMap:
+          name: in-cluster-ip-pool
+      initContainers:
+      - name: wait-crds
+        image: "quay.io/giantswarm/docker-kubectl:latest"
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        args:
+        - -c
+        - |
+          while ! kubectl get crd inclusterippools.ipam.cluster.x-k8s.io
+          do
+            echo "Waiting for CRD inclusterippools.ipam.cluster.x-k8s.io to exist"
+            sleep 5
+          done
+      containers:
+      - name: create-in-cluster-ip-pool
+        image: "quay.io/giantswarm/docker-kubectl:latest"
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: in-cluster-ip-pool
+          mountPath: /pool
+        command:
+        - sh
+        args:
+        - -c
+        - |
+          set -o errexit ; set -o xtrace ; set -o nounset
+          kubectl apply --server-side=true --field-manager='kubectl-client-side-apply' --force-conflicts -f /pool/ 2>&1
+{{- end }}
+{{- end }}

--- a/helm/cluster-api-ipam-provider-in-cluster/templates/pools/pool.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/templates/pools/pool.yaml
@@ -1,22 +1,33 @@
 {{- if .Values.enabled }}
 {{- with .Values.inClusterIpPool }}
 {{- if .enabled }}
-apiVersion: ipam.cluster.x-k8s.io/v1alpha1
-kind: InClusterIPPool
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: {{ .name }}
-spec:
-  gateway: 0.0.0.0
-  prefix: 24
-{{- if .start }}
-  start: {{ .start }}
-  end: {{ .end }}
-{{- else }}
-  addresses:
-  {{- range .addresses }}
-  - {{ . }}
-  {{- end }}
-{{- end }}
+  name: in-cluster-ip-pool
+  namespace: {{ $.Release.Namespace }}
+  annotations:
+    helm.sh/hook: "post-install,post-upgrade"
+    helm.sh/hook-delete-policy: "before-hook-creation,hook-succeeded,hook-failed"
+    helm.sh/hook-weight: "-2"
+data:
+  pool.yaml: |-
+    apiVersion: ipam.cluster.x-k8s.io/v1alpha1
+    kind: InClusterIPPool
+    metadata:
+      name: {{ .name }}
+    spec:
+      gateway: 0.0.0.0
+      prefix: 24
+    {{- if .start }}
+      start: {{ .start }}
+      end: {{ .end }}
+    {{- else }}
+      addresses:
+      {{- range .addresses }}
+      - {{ . }}
+      {{- end }}
+    {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/cluster-api-ipam-provider-in-cluster/templates/pools/rbac.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/templates/pools/rbac.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.enabled }}
+{{- if .Values.inClusterIpPool.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: install-crs
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: "post-install,post-upgrade"
+    helm.sh/hook-delete-policy: "before-hook-creation,hook-succeeded,hook-failed"
+    helm.sh/hook-weight: "-2"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: install-crs
+rules:
+- apiGroups:
+  - ipam.cluster.x-k8s.io
+  resources:
+  - inclusterippools
+  verbs:
+  - patch
+  - create
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  resourceNames:
+  - inclusterippools.ipam.cluster.x-k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: install-crs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: install-crs
+subjects:
+- kind: ServiceAccount
+  name: install-crs
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
This went under the radar, because I had the CRDs always present on the cluster where I tested the chart. When installing it on a new cluster it hits this issue:

```
      invalid manifest error: (unable to build kubernetes objects from release manifest: resource mapping not found for name: "wc-cp-ips" namespace: "" from "": no matches for kind "InClusterIPPool" in version "ipam.cluster.x-k8s.io/v1alpha1"
```

so although the crds are being created in the install-crd job, it's still not enough, because the chart can't be applied if it contains the unknown CRs.. this way we well be creating the pool in post-install hook which waits for the crds to be present. Similarly as cilium-app does.