### PR TITLE
certificate name should be caip-serving-cert -> caip-in-cluster-serving-cert

### DIFF
--- a/config/kustomize/patches/crd_cainjection.yaml
+++ b/config/kustomize/patches/crd_cainjection.yaml
@@ -5,4 +5,4 @@ kind: CustomResourceDefinition
 metadata:
   name: "ignored" # not relevant as we are applying this patch to all CAIP CRDs via labelSelector
   annotations:
-    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/caip-serving-cert"
+    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/caip-in-cluster-serving-cert"

--- a/config/kustomize/patches/webhook-certificate.yaml
+++ b/config/kustomize/patches/webhook-certificate.yaml
@@ -4,11 +4,11 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: caip-in-cluster-mutating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/caip-serving-cert"
+    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/caip-in-cluster-serving-cert"
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: caip-in-cluster-validating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/caip-serving-cert"
+    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/caip-in-cluster-serving-cert"

--- a/helm/cluster-api-ipam-provider-in-cluster/files/globalinclusterippools.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/files/globalinclusterippools.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/caip-serving-cert'
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/caip-in-cluster-serving-cert'
     controller-gen.kubebuilder.io/version: v0.7.0
   labels:
     app.giantswarm.io/branch: '{{ .Values.project.branch }}'

--- a/helm/cluster-api-ipam-provider-in-cluster/files/inclusterippools.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/files/inclusterippools.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/caip-serving-cert'
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/caip-in-cluster-serving-cert'
     controller-gen.kubebuilder.io/version: v0.7.0
   labels:
     app.giantswarm.io/branch: '{{ .Values.project.branch }}'

--- a/helm/cluster-api-ipam-provider-in-cluster/templates/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_caip-in-cluster-mutating-webhook-configuration.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/templates/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_caip-in-cluster-mutating-webhook-configuration.yaml
@@ -3,7 +3,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/caip-serving-cert'
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/caip-in-cluster-serving-cert'
   labels:
     app.giantswarm.io/branch: '{{ .Values.project.branch }}'
     app.giantswarm.io/commit: '{{ .Values.project.commit }}'

--- a/helm/cluster-api-ipam-provider-in-cluster/templates/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_caip-in-cluster-validating-webhook-configuration.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/templates/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_caip-in-cluster-validating-webhook-configuration.yaml
@@ -3,7 +3,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/caip-serving-cert'
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/caip-in-cluster-serving-cert'
   labels:
     app.giantswarm.io/branch: '{{ .Values.project.branch }}'
     app.giantswarm.io/commit: '{{ .Values.project.commit }}'

--- a/helm/cluster-api-ipam-provider-in-cluster/templates/crd-install/crd-job.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/templates/crd-install/crd-job.yaml
@@ -14,6 +14,7 @@ metadata:
     {{- include "labels.selector" . | nindent 4 }}
     role: {{ include "crdInstallSelector" . | quote }}
 spec:
+  ttlSecondsAfterFinished: 43200 # 12h
   template:
     metadata:
       labels:

--- a/helm/cluster-api-ipam-provider-in-cluster/templates/pools/crs-netpol.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/templates/pools/crs-netpol.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.enabled }}
+{{- if .Values.inClusterIpPool.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: create-in-cluster-ip-pool-job-talks-to-apiserver
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "-2"
+    helm.sh/hook-delete-policy: "before-hook-creation,hook-succeeded,hook-failed"
+spec:
+  podSelector:
+    matchLabels:
+      app: create-in-cluster-ip-pool
+  # allow egress traffic to the Kubernetes API
+  egress:
+  - ports:
+    - port: 443
+      protocol: TCP
+    # legacy port kept for compatibility
+    - port: 6443
+      protocol: TCP
+    to:
+    {{- range tuple "10.0.0.0/8" "172.16.0.0/12" "192.168.0.0/16" "100.64.0.0/10" }}
+    - ipBlock:
+        cidr: {{ . }}
+    {{- end }}
+  # deny ingress traffic
+  ingress: []
+  policyTypes:
+  - Egress
+  - Ingress
+{{- if .Values.ciliumNetworkPolicy.enabled }}
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: create-in-cluster-ip-pool-job-talks-to-apiserver
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "-2"
+    helm.sh/hook-delete-policy: "before-hook-creation,hook-succeeded,hook-failed"
+spec:
+  endpointSelector:
+    matchLabels:
+      app: create-in-cluster-ip-pool
+  egress:
+    - toEntities:
+        - kube-apiserver
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm/cluster-api-ipam-provider-in-cluster/templates/pools/crs-netpol.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/templates/pools/crs-netpol.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-weight: "-2"
-    helm.sh/hook-delete-policy: "before-hook-creation,hook-succeeded,hook-failed"
+    helm.sh/hook-delete-policy: "before-hook-creation,hook-succeeded"
 spec:
   podSelector:
     matchLabels:
@@ -41,7 +41,7 @@ metadata:
   annotations:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-weight: "-2"
-    helm.sh/hook-delete-policy: "before-hook-creation,hook-succeeded,hook-failed"
+    helm.sh/hook-delete-policy: "before-hook-creation,hook-succeeded"
 spec:
   endpointSelector:
     matchLabels:

--- a/helm/cluster-api-ipam-provider-in-cluster/templates/pools/job.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/templates/pools/job.yaml
@@ -10,7 +10,7 @@ metadata:
   annotations:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-weight: "-1"
-    helm.sh/hook-delete-policy: "before-hook-creation,hook-succeeded,hook-failed"
+    helm.sh/hook-delete-policy: "before-hook-creation,hook-succeeded"
 spec:
   backoffLimit: 50
   template:

--- a/helm/cluster-api-ipam-provider-in-cluster/templates/pools/job.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/templates/pools/job.yaml
@@ -12,6 +12,7 @@ metadata:
     helm.sh/hook-weight: "-1"
     helm.sh/hook-delete-policy: "before-hook-creation,hook-succeeded"
 spec:
+  ttlSecondsAfterFinished: 43200 # 12h
   backoffLimit: 50
   template:
     metadata:

--- a/helm/cluster-api-ipam-provider-in-cluster/templates/pools/pool.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/templates/pools/pool.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   annotations:
     helm.sh/hook: "post-install,post-upgrade"
-    helm.sh/hook-delete-policy: "before-hook-creation,hook-succeeded,hook-failed"
+    helm.sh/hook-delete-policy: "before-hook-creation,hook-succeeded"
     helm.sh/hook-weight: "-2"
 data:
   pool.yaml: |-

--- a/helm/cluster-api-ipam-provider-in-cluster/templates/pools/rbac.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/templates/pools/rbac.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     helm.sh/hook: "post-install,post-upgrade"
-    helm.sh/hook-delete-policy: "before-hook-creation,hook-succeeded,hook-failed"
+    helm.sh/hook-delete-policy: "before-hook-creation,hook-succeeded"
     helm.sh/hook-weight: "-2"
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/cluster-api-ipam-provider-in-cluster/templates/pools/rbac.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/templates/pools/rbac.yaml
@@ -14,6 +14,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: install-crs
+  annotations:
+    helm.sh/hook: "post-install,post-upgrade"
+    helm.sh/hook-delete-policy: "before-hook-creation,hook-succeeded"
+    helm.sh/hook-weight: "-2"
 rules:
 - apiGroups:
   - ipam.cluster.x-k8s.io
@@ -35,6 +39,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: install-crs
+  annotations:
+    helm.sh/hook: "post-install,post-upgrade"
+    helm.sh/hook-delete-policy: "before-hook-creation,hook-succeeded"
+    helm.sh/hook-weight: "-2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
`create-in-cluster-ip-pool` job:
```
Error from server (InternalError): Internal error occurred: failed calling webhook "default.inclusterippool.ipam.cluster.x-k8s.io": failed to call webhook: Post "https://caip-in-cluster-webhook-service.giantswarm.svc:443/mutate-ipam-cluster-x-k8s-io-v1alpha1-inclusterippool?timeout=10s": context deadline exceeded
```

manager itself:
```
1.6884864051832612e+09	ERROR	setup	problem running manager	{"error": "open /tmp/k8s-webhook-server/serving-certs/tls.crt: no such file or directory"}
```

(the value should be same as in here https://github.com/giantswarm/cluster-api-ipam-provider-in-cluster-app/blob/main/config/kustomize/patches/certificate.yaml#L5)