### PR TITLE
Manager can't start because of missing cert & netpol names

### DIFF
--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -9,7 +9,7 @@ REPO_NAME="cluster-api-ipam-provider-in-cluster"
 TAG_TO_SYNC="v0.1.0-alpha.2"
 
 .PHONY: all
-all: fetch-upstream-manifest apply-kustomize-patches apply-custom-patches delete-generated-helm-charts release-manifests ## Builds the manifests to publish with a release (alias to release-manifests)
+all: fetch-upstream-manifest apply-kustomize-patches delete-generated-helm-charts release-manifests apply-custom-patches ## Builds the manifests to publish with a release (alias to release-manifests)
 
 .PHONY: fetch-upstream-manifest
 fetch-upstream-manifest: ## fetch upstream manifest from upstream repo

--- a/config/kustomize/kustomization.yaml
+++ b/config/kustomize/kustomization.yaml
@@ -29,15 +29,5 @@ patches:
   target:
     kind: CustomResourceDefinition
     labelSelector: cluster.x-k8s.io/provider=ipam-in-cluster
-- patch: |-
-    - op: remove
-      path: /spec/template/spec/volumes/0
-    - op: remove
-      path: /spec/template/spec/containers/0/volumeMounts/0
-  target:
-    group: apps
-    kind: Deployment
-    name: caip-in-cluster-controller-manager
-    version: v1
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/config/kustomize/patches/certificate.yaml
+++ b/config/kustomize/patches/certificate.yaml
@@ -12,4 +12,4 @@ spec:
     group: cert-manager.io
     kind: ClusterIssuer
     name: selfsigned-giantswarm
-  secretName: caip-webhook-server-cert
+  secretName: caip-in-cluster-webhook-service-cert

--- a/config/kustomize/patches/deployment-resources.yaml
+++ b/config/kustomize/patches/deployment-resources.yaml
@@ -25,4 +25,4 @@ spec:
       - name: cert
         secret:
           defaultMode: 420
-          secretName: caip-webhook-server-cert
+          secretName: caip-in-cluster-webhook-service-cert

--- a/helm/cluster-api-ipam-provider-in-cluster/templates/apps_v1_deployment_caip-in-cluster-controller-manager.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/templates/apps_v1_deployment_caip-in-cluster-controller-manager.yaml
@@ -61,12 +61,19 @@ spec:
             memory: '{{ .Values.resources.requests.memory }}'
         securityContext:
           allowPrivilegeEscalation: false
-        volumeMounts: []
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
       serviceAccountName: caip-in-cluster-controller-manager
       terminationGracePeriodSeconds: 10
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/control-plane
         operator: Exists
-      volumes: []
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: caip-in-cluster-webhook-service-cert
 {{- end }}

--- a/helm/cluster-api-ipam-provider-in-cluster/templates/cert-manager.io_v1_certificate_caip-in-cluster-serving-cert.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/templates/cert-manager.io_v1_certificate_caip-in-cluster-serving-cert.yaml
@@ -21,7 +21,7 @@ spec:
     group: cert-manager.io
     kind: ClusterIssuer
     name: selfsigned-giantswarm
-  secretName: caip-webhook-server-cert
+  secretName: caip-in-cluster-webhook-service-cert
   subject:
     organizations:
     - k8s-sig-cluster-lifecycle

--- a/helm/cluster-api-ipam-provider-in-cluster/templates/custom/manager-netpol.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/templates/custom/manager-netpol.yaml
@@ -2,7 +2,7 @@
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
-  name: {{ $.Release.Namespace }}
+  name: caip-in-cluster-controller-manager
   namespace: {{ .Release.Namespace | quote }}
   labels:
     app.giantswarm.io/branch: '{{ .Values.project.branch }}'
@@ -41,7 +41,7 @@ spec:
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: {{ $.Release.Namespace }}
+  name: caip-in-cluster-controller-manager
   namespace: {{ .Release.Namespace | quote }}
   labels:
     app.giantswarm.io/branch: '{{ .Values.project.branch }}'


### PR DESCRIPTION
currently can't start because of:

```
1.6890855316222022e+09	INFO	Stopping and waiting for webhooks
1.6890855316222136e+09	INFO	Wait completed, proceeding to shutdown the manager
E0711 14:25:31.622265       1 leaderelection.go:330] error retrieving resource lock giantswarm/7bb7acb4.ipam.cluster.x-k8s.io: Get "https://172.31.0.1:443/apis/coordination.k8s.io/v1/namespaces/giantswarm/leases/7bb7acb4.ipam.cluster.x-k8s.io": context canceled
1.6890855316222935e+09	ERROR	setup	problem running manager	{"error": "open /tmp/k8s-webhook-server/serving-certs/tls.crt: no such file or directory"}
```

with this change it can start and work properly, I tested this using 
```
helm upgrade -i caip helm/cluster-api-ipam-provider-in-cluster --set ciliumNetworkPolicy.enabled=true
```

also changing the names of the network policies, because there were called after the release namespace (typo)