### PR TITLE
Volume mount needs also subPath

### DIFF
--- a/helm/cluster-api-ipam-provider-in-cluster/templates/pools/crs-netpol.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/templates/pools/crs-netpol.yaml
@@ -49,6 +49,7 @@ spec:
   egress:
     - toEntities:
         - kube-apiserver
+        - cluster
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/cluster-api-ipam-provider-in-cluster/templates/pools/job.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/templates/pools/job.yaml
@@ -63,7 +63,14 @@ spec:
         args:
         - -c
         - |
-          set -o errexit ; set -o xtrace ; set -o nounset
-          kubectl apply --server-side=true --field-manager='kubectl-client-side-apply' --force-conflicts -f /data/ 2>&1
+          set -o nounset
+          for i in $(seq 20)
+          do
+            kubectl apply -f /data/ 2>&1 && exit 0
+            _sec=$(echo "1.5^$i" | bc)
+            echo "Waiting ${_sec} seconds.."
+            sleep ${_sec}
+          done
+          exit 1
 {{- end }}
 {{- end }}

--- a/helm/cluster-api-ipam-provider-in-cluster/templates/pools/job.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/templates/pools/job.yaml
@@ -57,6 +57,7 @@ spec:
         volumeMounts:
         - name: in-cluster-ip-pool
           mountPath: /data/pool.yaml
+          subPath: pool.yaml
         command:
         - sh
         args:

--- a/helm/cluster-api-ipam-provider-in-cluster/templates/pools/rbac.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/templates/pools/rbac.yaml
@@ -26,6 +26,7 @@ rules:
   verbs:
   - patch
   - create
+  - get
 - apiGroups:
   - apiextensions.k8s.io
   resources:


### PR DESCRIPTION
there are three unrelated things in this pr:
- relaxing the cilium netpol, because when creating the `InClusterIpPool` by a job, it first tries to talk to the mutating webhook which is available as a service -> adding `cluster`
- add subPath when mounting the yaml with CR
- wrap the call that creates the CR in a exponential back-off loop (`1.5^{1..20}`)

The last point is needed because when deploying the app, it takes some time for the webhook to be ready (it requires also certificate -> dns01 challenge in closed environments). otherwise I was observing these errors:

```
Resource: "ipam.cluster.x-k8s.io/v1alpha1, Resource=inclusterippools", GroupVersionKind: "ipam.cluster.x-k8s.io/v1alpha1, Kind=InClusterIPPool"
Name: "wc-cp-ips", Namespace: "giantswarm"
for: "/data/pool.yaml": error when patching "/data/pool.yaml": Internal error occurred: failed calling webhook "default.inclusterippool.ipam.cluster.x-k8s.io": failed to call webhook: Post "https://caip-in-cluster-webhook-service.giantswarm.svc:443/mutate-ipam-cluster-x-k8s-io-v1alpha1-inclusterippool?timeout=10s": context deadline exceeded
```