### PR TITLE
network policies for webhooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Network policy (cilium and normal) for webhooks.
+
 ## [0.0.5] - 2023-07-11
 
 ## [0.0.4] - 2023-07-11

--- a/config/kustomize/patches/crd_webhook.yaml
+++ b/config/kustomize/patches/crd_webhook.yaml
@@ -13,5 +13,5 @@ spec:
       clientConfig:
         service:
           namespace: "{{ .Release.Namespace }}"
-          name: caip-webhook-service
+          name: caip-in-cluster-webhook-service
           path: /convert

--- a/helm/cluster-api-ipam-provider-in-cluster/files/globalinclusterippools.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/files/globalinclusterippools.yaml
@@ -20,7 +20,7 @@ spec:
     webhook:
       clientConfig:
         service:
-          name: caip-webhook-service
+          name: caip-in-cluster-webhook-service
           namespace: '{{ .Release.Namespace }}'
           path: /convert
       conversionReviewVersions:

--- a/helm/cluster-api-ipam-provider-in-cluster/files/inclusterippools.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/files/inclusterippools.yaml
@@ -20,7 +20,7 @@ spec:
     webhook:
       clientConfig:
         service:
-          name: caip-webhook-service
+          name: caip-in-cluster-webhook-service
           namespace: '{{ .Release.Namespace }}'
           path: /convert
       conversionReviewVersions:

--- a/helm/cluster-api-ipam-provider-in-cluster/templates/custom/manager-netpol.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/templates/custom/manager-netpol.yaml
@@ -36,6 +36,31 @@ spec:
   policyTypes:
   - Egress
   - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-caip-webhooks
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.giantswarm.io/branch: '{{ .Values.project.branch }}'
+    app.giantswarm.io/commit: '{{ .Values.project.commit }}'
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
+    app.kubernetes.io/name: '{{ .Chart.Name }}'
+    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+    cluster.x-k8s.io/provider: ipam-in-cluster
+    helm.sh/chart: '{{ .Chart.Name }}'
+spec:
+  ingress:
+  - from:
+    - namespaceSelector: {}
+  podSelector:
+    matchLabels:
+      cluster.x-k8s.io/provider: ipam-in-cluster
+      control-plane: controller-manager
+  policyTypes:
+  - Ingress
 {{- if .Values.ciliumNetworkPolicy.enabled }}
 ---
 apiVersion: cilium.io/v2
@@ -60,5 +85,28 @@ spec:
   egress:
     - toEntities:
         - kube-apiserver
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-caip-webhooks
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.giantswarm.io/branch: '{{ .Values.project.branch }}'
+    app.giantswarm.io/commit: '{{ .Values.project.commit }}'
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
+    app.kubernetes.io/name: '{{ .Chart.Name }}'
+    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+    cluster.x-k8s.io/provider: ipam-in-cluster
+    helm.sh/chart: '{{ .Chart.Name }}'
+spec:
+  endpointSelector:
+    matchLabels:
+      cluster.x-k8s.io/provider: ipam-in-cluster
+      control-plane: controller-manager
+  ingress:
+  - from:
+    - world
 {{- end }}
 {{- end }}


### PR DESCRIPTION
w/o such policy this timeouts:

```
k run -it --image=infoblox/dnstools --rm --restart=Never --command debug -n org-giantswarm -- curl -k https://caip-in-cluster-webhook-service.giantswarm.svc:443/mutate-ipam-cluster-x-k8s-io-v1alpha1-inclusterippool
```
if I create those policies manually I am getting

```
{"response":{"uid":"","allowed":false,"status":{"metadata":{},"message":"contentType=, expected application/json","code":400}}}
```
which is good