### PR TITLE
InClusterIPPool -> GlobalInClusterIPPool (namespace scope not required)

### DIFF
--- a/helm/cluster-api-ipam-provider-in-cluster/templates/pools/pool.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/templates/pools/pool.yaml
@@ -13,7 +13,7 @@ metadata:
 data:
   content: |
     apiVersion: ipam.cluster.x-k8s.io/v1alpha1
-    kind: InClusterIPPool
+    kind: GlobalInClusterIPPool
     metadata:
       name: {{ .name }}
     spec:


### PR DESCRIPTION
in fact the upstream controller has a bug (*) present when `IpAddressClaim` is created in other namespace than `InClusterIpPool`. The ref to pool doesn't contain the namespace. I might open a pr upstream for this. Workaround is to use `GlobalInClusterIpPool` which works cross-namespaces.

(*)
```
new-cluster-claim2", "reconcileID": "2c376654-a037-41c0-b90e-d9d8ebc08014", "pool name": "", "error": "failed to convert IPAddressList to set: failed to parse gateway ip: ParseIP(\"\"): unable to parse IP"}
github.com/telekom/cluster-api-ipam-provider-in-cluster/internal/controllers.(*IPAddressClaimReconciler).Reconcile
	github.com/telekom/cluster-api-ipam-provider-in-cluster/internal/controllers/ipaddressclaim.go:152
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile
	sigs.k8s.io/controller-runtime@v0.13.1/pkg/internal/controller/controller.go:121
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	sigs.k8s.io/controller-runtime@v0.13.1/pkg/internal/controller/controller.go:320
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	sigs.k8s.io/controller-runtime@v0.13.1/pkg/internal/controller/controller.go:273
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	sigs.k8s.io/controller-runtime@v0.13.1/pkg/internal/controller/controller.go:234
```

todo: change that also in cluster-vsphere when creating the claim