### PR TITLE
PSS (jobs), the deployment itself is ok

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- PSS compliance
+
 ## [0.0.12] - 2023-08-08
 
 ### Changed

--- a/helm/cluster-api-ipam-provider-in-cluster/templates/crd-install/crd-job.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/templates/crd-install/crd-job.yaml
@@ -25,6 +25,9 @@ spec:
       securityContext:
         runAsUser: 1000
         runAsGroup: 2000
+        {{- with .Values.podSecurityContext }}
+        {{- . | toYaml | nindent 8 }}
+        {{- end }}
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
@@ -41,6 +44,9 @@ spec:
           kubectl apply -f /data/ 2>&1
         securityContext:
           readOnlyRootFilesystem: true
+          {{- with .Values.containerSecurityContext }}
+          {{- . | toYaml | nindent 10 }}
+          {{- end }}
         volumeMounts:
 {{- range $path, $_ := .Files.Glob "files/**" }}
         - name: {{ $path | base | trimSuffix ".yaml" }}

--- a/helm/cluster-api-ipam-provider-in-cluster/templates/crd-install/crd-psp.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/templates/crd-install/crd-psp.yaml
@@ -1,10 +1,13 @@
 {{- if .Values.enabled }}
 {{- if .Values.crds.install }}
+{{- if not .Values.global.podSecurityStandards.enforced }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ include "crdInstall" . }}
   annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
     # create hook dependencies in the right order
     "helm.sh/hook-weight": "-6"
     {{- include "crdInstallAnnotations" . | nindent 4 }}
@@ -34,5 +37,7 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: false
+{{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm/cluster-api-ipam-provider-in-cluster/templates/pools/job.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/templates/pools/job.yaml
@@ -24,6 +24,9 @@ spec:
       securityContext:
         runAsUser: 1000
         runAsGroup: 2000
+        {{- with .Values.podSecurityContext }}
+        {{- . | toYaml | nindent 8 }}
+        {{- end }}
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
@@ -48,6 +51,10 @@ spec:
             echo "Waiting for CRD inclusterippools.ipam.cluster.x-k8s.io to exist"
             sleep 5
           done
+        {{- with .Values.containerSecurityContext }}
+        securityContext:
+          {{- . | toYaml | nindent 10 }}
+        {{- end }}
       containers:
       - name: create-in-cluster-ip-pool
         image: "quay.io/giantswarm/docker-kubectl:latest"
@@ -72,5 +79,9 @@ spec:
             sleep ${_sec}
           done
           exit 1
+        {{- with .Values.containerSecurityContext }}
+        securityContext:
+          {{- . | toYaml | nindent 10 }}
+        {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/cluster-api-ipam-provider-in-cluster/values.schema.json
+++ b/helm/cluster-api-ipam-provider-in-cluster/values.schema.json
@@ -25,6 +25,19 @@
       "title": "Enabled",
       "description": "Should the chart be rendered"
     },
+    "global": {
+      "type": "object",
+      "properties": {
+          "podSecurityStandards": {
+              "type": "object",
+              "properties": {
+                  "enforced": {
+                      "type": "boolean"
+                  }
+              }
+          }
+      }
+    },
     "crds": {
       "type": "object",
       "properties": {

--- a/helm/cluster-api-ipam-provider-in-cluster/values.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/values.yaml
@@ -32,3 +32,23 @@ inClusterIpPool:
 
 ciliumNetworkPolicy:
   enabled: false
+
+# Add seccomp to pod security context
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+# Add seccomp to container security context
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+global:
+  podSecurityStandards:
+    enforced: false


### PR DESCRIPTION
with this change the only issue is `EndpointSlice` (control plane thing)

```
kubectl get polr -A -n giantswarm -ojsonpath='{.items[*].results[?(@.result=="fail")]}' | jq 'select(.resources[].name | contains("caip")) | .message'                                 ○ gcapeverde-admin@gcapeverde
"discovery.k8s.io/v1beta1/EndpointSlice is deprecated and will be removed in v1.25. See: https://kubernetes.io/docs/reference/using-api/deprecation-guide/"
"discovery.k8s.io/v1beta1/EndpointSlice is deprecated and will be removed in v1.25. See: https://kubernetes.io/docs/reference/using-api/deprecation-guide/"
```