### PR TITLE
Support for multiple pools

### DIFF
--- a/helm/cluster-api-ipam-provider-in-cluster/templates/pools/job.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/templates/pools/job.yaml
@@ -1,12 +1,13 @@
 {{- if .Values.enabled }}
 {{- if .Values.inClusterIpPool.enabled }}
+{{- if .Values.inClusterIpPool.pools }}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: create-in-cluster-ip-pool
+  name: create-in-cluster-ip-pools
   namespace: {{ .Release.Namespace }}
   labels:
-    app: create-in-cluster-ip-pool
+    app: create-in-cluster-ip-pools
   annotations:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-weight: "-1"
@@ -17,7 +18,7 @@ spec:
   template:
     metadata:
       labels:
-        app: create-in-cluster-ip-pool
+        app: create-in-cluster-ip-pools
     spec:
       restartPolicy: Never
       serviceAccountName: install-crs
@@ -31,12 +32,14 @@ spec:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
       volumes:
-      - name: in-cluster-ip-pool
+      {{- range .Values.inClusterIpPool.pools }}
+      - name: ip-pool-{{ .name }}
         configMap:
-          name: in-cluster-ip-pool
+          name: ip-pool-{{ .name }}
           items:
-          - key: content
-            path: pool.yaml
+          - key: {{ .name }}
+            path: {{ .name }}.yaml
+      {{- end }}
       initContainers:
       - name: wait-crds
         image: "quay.io/giantswarm/docker-kubectl:latest"
@@ -56,15 +59,17 @@ spec:
           {{- . | toYaml | nindent 10 }}
         {{- end }}
       containers:
-      - name: create-in-cluster-ip-pool
+      - name: create-in-cluster-ip-pools
         image: "quay.io/giantswarm/docker-kubectl:latest"
         imagePullPolicy: IfNotPresent
         securityContext:
           readOnlyRootFilesystem: true
         volumeMounts:
-        - name: in-cluster-ip-pool
-          mountPath: /data/pool.yaml
-          subPath: pool.yaml
+        {{- range .Values.inClusterIpPool.pools }}
+        - name: ip-pool-{{ .name }}
+          mountPath: /data/{{ .name }}.yaml
+          subPath: {{ .name }}.yaml
+        {{- end }}
         command:
         - sh
         args:
@@ -83,5 +88,6 @@ spec:
         securityContext:
           {{- . | toYaml | nindent 10 }}
         {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm/cluster-api-ipam-provider-in-cluster/templates/pools/job.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/templates/pools/job.yaml
@@ -37,7 +37,7 @@ spec:
         configMap:
           name: ip-pool-{{ .name }}
           items:
-          - key: {{ .name }}
+          - key: content
             path: {{ .name }}.yaml
       {{- end }}
       initContainers:

--- a/helm/cluster-api-ipam-provider-in-cluster/templates/pools/pool.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/templates/pools/pool.yaml
@@ -1,10 +1,11 @@
 {{- if .Values.enabled }}
 {{- with .Values.inClusterIpPool }}
 {{- if .enabled }}
+{{- range .pools }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: in-cluster-ip-pool
+  name: ip-pool-{{ .name }}
   namespace: {{ $.Release.Namespace }}
   annotations:
     helm.sh/hook: "post-install,post-upgrade"
@@ -26,6 +27,8 @@ data:
       {{- range .addresses }}
       - {{ . }}
       {{- end }}
+---
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/cluster-api-ipam-provider-in-cluster/templates/pools/pool.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/templates/pools/pool.yaml
@@ -17,6 +17,15 @@ data:
     kind: GlobalInClusterIPPool
     metadata:
       name: {{ .name }}
+      labels:
+        app.giantswarm.io/branch: '{{ $.Values.project.branch }}'
+        app.giantswarm.io/commit: '{{ $.Values.project.commit }}'
+        app.kubernetes.io/instance: '{{ $.Release.Name }}'
+        app.kubernetes.io/managed-by: '{{ $.Release.Service }}'
+        app.kubernetes.io/name: '{{ $.Chart.Name }}'
+        app.kubernetes.io/version: '{{ $.Chart.AppVersion }}'
+        cluster.x-k8s.io/provider: ipam-in-cluster
+        helm.sh/chart: '{{ $.Chart.Name }}'
     spec:
       gateway: 0.0.0.0
       prefix: 24

--- a/helm/cluster-api-ipam-provider-in-cluster/values.schema.json
+++ b/helm/cluster-api-ipam-provider-in-cluster/values.schema.json
@@ -85,10 +85,6 @@
               "description": "Create also InClusterIpPool resource"
           }
       },
-      "dependencies": {
-        "start": ["end"],
-        "end": ["start"]
-      },
       "if": {
         "properties": { "enabled": { "const": true } }
       },
@@ -123,6 +119,10 @@
                     "pattern": "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(/([0-9]|[1,2][0-9]|[3][0-2]))?$"
                   }
                 }
+              },
+              "dependencies": {
+                "start": ["end"],
+                "end": ["start"]
               },
               "oneOf": [
                 { "required": ["start"] },

--- a/helm/cluster-api-ipam-provider-in-cluster/values.schema.json
+++ b/helm/cluster-api-ipam-provider-in-cluster/values.schema.json
@@ -83,9 +83,6 @@
               "default": false,
               "title": "InClusterIpPool",
               "description": "Create also InClusterIpPool resource"
-          },
-          "name": {
-              "type": "string"
           }
       },
       "dependencies": {
@@ -97,38 +94,46 @@
       },
       "then": {
         "properties": {
-          "name": {
-            "type": "string",
-            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
-            "title": "Name",
-            "description": "Name of the InClusterIpPool resource"
-          },
-          "start": {
-            "$ref": "#/$defs/ipv4",
-            "title": "Start",
-            "description": "The first allocatable IPv4 address"
-          },
-          "end": {
-            "$ref": "#/$defs/ipv4",
-            "title": "End",
-            "description": "The last allocatable IPv4 address (inclusive). Must be higher or equal than start."
-          },
-          "addresses": {
+          "pools": {
             "type": "array",
             "items": {
-              "type": "string",
-              "description": "IPv4 address in CIDR notation specifying the segment of the network",
-              "pattern": "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(/([0-9]|[1,2][0-9]|[3][0-2]))?$"
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                  "title": "Name",
+                  "description": "Name of the InClusterIpPool resource"
+                },
+                "start": {
+                  "$ref": "#/$defs/ipv4",
+                  "title": "Start",
+                  "description": "The first allocatable IPv4 address"
+                },
+                "end": {
+                  "$ref": "#/$defs/ipv4",
+                  "title": "End",
+                  "description": "The last allocatable IPv4 address (inclusive). Must be higher or equal than start."
+                },
+                "addresses": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "description": "IPv4 address in CIDR notation specifying the segment of the network",
+                    "pattern": "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(/([0-9]|[1,2][0-9]|[3][0-2]))?$"
+                  }
+                }
+              },
+              "oneOf": [
+                { "required": ["start"] },
+                { "required": ["addresses"] }
+              ],
+              "required": [
+                "name"
+              ]
             }
           }
-        },
-        "oneOf": [
-          { "required": ["start"] },
-          { "required": ["addresses"] }
-        ],
-        "required": [
-          "name"
-        ]
+        }
       },
       "required": [
         "enabled"

--- a/helm/cluster-api-ipam-provider-in-cluster/values.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/values.yaml
@@ -23,12 +23,16 @@ resources:
 
 inClusterIpPool:
   enabled: false
-  name: wc-cp-ips
-  # use either start & end or adresses
-  start: 10.10.222.222
-  end: 10.10.222.229
-  # addresses:
-  # - 10.10.222.223/28
+  pools:
+  - name: wc-cp-ips
+    # use either start & end or adresses
+    start: 10.10.222.222
+    end: 10.10.222.225
+    # addresses:
+    # - 10.10.222.223/28
+  - name: svc-lb-ips
+    start: 10.10.222.226
+    end: 10.10.222.229
 
 ciliumNetworkPolicy:
   enabled: false

--- a/helm/cluster-api-ipam-provider-in-cluster/values.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/values.yaml
@@ -26,13 +26,13 @@ inClusterIpPool:
   pools:
   - name: wc-cp-ips
     # use either start & end or addresses
-    start: 10.10.222.222
-    end: 10.10.222.225
+    start: 10.0.1.1
+    end: 10.0.1.127
     # addresses:
-    # - 10.10.222.223/28
+    # - 10.0.1.1/25
   - name: svc-lb-ips
-    start: 10.10.222.226
-    end: 10.10.222.229
+    start: 10.0.1.128
+    end: 10.0.1.254
 
 ciliumNetworkPolicy:
   enabled: false

--- a/helm/cluster-api-ipam-provider-in-cluster/values.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/values.yaml
@@ -25,7 +25,7 @@ inClusterIpPool:
   enabled: false
   pools:
   - name: wc-cp-ips
-    # use either start & end or adresses
+    # use either start & end or addresses
     start: 10.10.222.222
     end: 10.10.222.225
     # addresses:


### PR DESCRIPTION
tested on gmc:

```
helm upgrade -i ipam control-plane-test-catalog/cluster-api-ipam-provider-in-cluster -n giantswarm --set inClusterIpPool.enabled=true --version 0.0.12-5c6fb04efd851eb956685b6c840dfae3b7a17e49
k get globalinclusterippools.ipam.cluster.x-k8s.io                                                                                                                                                                  21s ○ gmc-admin@gmc
NAME         ADDRESSES                   TOTAL   FREE   USED
svc-lb-ips   ["10.0.1.128-10.0.1.254"]   127     127    0
wc-cp-ips    ["10.0.1.1-10.0.1.127"]     127     127    0
```