### PR TITLE
use tagged/released image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Using the released image (it's the same as before, but nicer tag)
+
 ## [0.0.12] - 2023-10-24
 
 ## [0.0.12] - 2023-10-24

--- a/helm/cluster-api-ipam-provider-in-cluster/values.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/values.yaml
@@ -2,8 +2,7 @@ enabled: true
 
 image:
   name: quay.io/giantswarm/cluster-api-ipam-provider-in-cluster
-  # todo: switch back to latest released image once they release
-  tag: 80ec908
+  tag: v0.1.0-alpha.3
 
 project:
   branch: ""


### PR DESCRIPTION
it's the same thing, but called differently (they made a [release](https://github.com/kubernetes-sigs/cluster-api-ipam-provider-in-cluster/issues/177))

edit:

## DON'T MERGE YET
this depends on:
- https://github.com/giantswarm/retagger/pull/946

They made a release, but the image wasn't pushed correctly to their repo and it looks like they are currently in the process of migration from that telekom registry to the google ones (gcr.io)




it's nothing critical, just an aesthetic improvement so that we don't depend on image that is tagged by a git sha, but inside these things are identical