### PR TITLE
Fix typo in labels for netpols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Pull image from Azure CR.
+- Fix typo in labels for netpols.
 
 ## [0.1.0] - 2023-10-31
 

--- a/helm/cluster-api-ipam-provider-in-cluster/templates/pools/crs-netpol.yaml
+++ b/helm/cluster-api-ipam-provider-in-cluster/templates/pools/crs-netpol.yaml
@@ -3,7 +3,7 @@
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
-  name: create-in-cluster-ip-pool-job-talks-to-apiserver
+  name: create-in-cluster-ip-pools-job-talks-to-apiserver
   namespace: {{ .Release.Namespace | quote }}
   annotations:
     helm.sh/hook: post-install,post-upgrade
@@ -12,7 +12,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: create-in-cluster-ip-pool
+      app: create-in-cluster-ip-pools
   # allow egress traffic to the Kubernetes API
   egress:
   - ports:
@@ -36,7 +36,7 @@ spec:
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: create-in-cluster-ip-pool-job-talks-to-apiserver
+  name: create-in-cluster-ip-pools-job-talks-to-apiserver
   namespace: {{ .Release.Namespace | quote }}
   annotations:
     helm.sh/hook: post-install,post-upgrade
@@ -45,7 +45,7 @@ metadata:
 spec:
   endpointSelector:
     matchLabels:
-      app: create-in-cluster-ip-pool
+      app: create-in-cluster-ip-pools
   egress:
     - toEntities:
         - kube-apiserver


### PR DESCRIPTION
I found this bug while creating `gravel`. Because of wrong labels, netpol doesn't work and IP pools are not created. 